### PR TITLE
wp_db_backup.sh should not run wp-cli from root

### DIFF
--- a/files/usr/local/sbin/wp_db_backup.sh
+++ b/files/usr/local/sbin/wp_db_backup.sh
@@ -5,7 +5,7 @@ for docroot in /var/www/*/wordpress; do
 	cd $docroot
 	dbinfo=($(grep DB_NAME ${docroot}/wp-config.php |tr "'" '\n'))
 	dbname=${dbinfo[3]}
-	wp --allow-root db export ${dbname}.sql || mysqldump ${dbname} > ${dbname}.sql
+	mysqldump ${dbname} > ${dbname}.sql
 	gzip ${dbname}.sql
 	mv ${dbname}.sql.gz ../
 	echo


### PR DESCRIPTION
`wp_db_backup.sh` should not run wp-cli from root as it includes code, that may be infected from wp-config.php (this task is in `/etc/cron.d/eqpress_backups` spawning such processes `root     12953 99.9  0.0 356904 41332 ?        R    Nov02 4861:35 php /usr/local/sbin/wp --allow-root db export dbname.sql`) . It is possible to use `mysqldump` instead