### PR TITLE
chwebown with xargs

### DIFF
--- a/files/usr/local/sbin/chwebown
+++ b/files/usr/local/sbin/chwebown
@@ -1,4 +1,4 @@
 #!/bin/bash
 ionice -c 3 chown -R www-data:www-data $1
-ionice -c 3 find $1 -type d -exec chmod 775 {} \;
-ionice -c 3 find $1 -type f -exec chmod 664 {} \;
+ionice -c 3 find $1 -type d -print0 | xargs -0 chmod 775
+ionice -c 3 find $1 -type f -print0 | xargs -0 chmod 644


### PR DESCRIPTION
old way is very slow - takes 15 minutes instead of 5 seconds (new way) on 602990 of file 43 Gb in size even on NVMe